### PR TITLE
Component demo tasks

### DIFF
--- a/src/webapp/routes/demo/__init__.py
+++ b/src/webapp/routes/demo/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
 
-demo_bp = Blueprint('demo', __name__, url_prefix='/demo')
+demo_bp = Blueprint('demo', __name__, url_prefix='/component-demo')
 
 from . import component_demo_handlers

--- a/src/webapp/routes/demo/component_demo_handlers.py
+++ b/src/webapp/routes/demo/component_demo_handlers.py
@@ -6,3 +6,9 @@ from . import demo_bp
 def index():
     """Component demonstration page for UI testing"""
     return render_template('pages/component_demo/component_demo.html')
+
+
+@demo_bp.route('/tasks/')
+def tasks():
+    """Component demonstration page for UI testing"""
+    return render_template('pages/component_demo/task_component_demo.html')

--- a/src/webapp/templates/components/tasks/task_create.html
+++ b/src/webapp/templates/components/tasks/task_create.html
@@ -1,0 +1,126 @@
+{# Task Create Component - Form for creating a new task #}
+
+{% macro task_create() %}
+<div x-data='taskCreate()' class="box">
+    <h3 class="title is-5 mb-4">Create New Task</h3>
+
+    <!-- Title Input -->
+    <div class="field mb-4">
+        <label class="label">Task Title *</label>
+        <div class="control">
+            <input class="input"
+                   type="text"
+                   x-model="formData.title"
+                   placeholder="Enter task title"
+                   :class="{ 'is-danger': errors.title }">
+        </div>
+        <p class="help is-danger" x-show="errors.title" x-text="errors.title"></p>
+    </div>
+
+    <!-- Description -->
+    <div class="field mb-4">
+        <label class="label">Description</label>
+        <div class="control">
+            <textarea class="textarea"
+                      x-model="formData.description"
+                      placeholder="Add details about this task (optional)"
+                      rows="4"></textarea>
+        </div>
+    </div>
+
+    <!-- Status and Active Toggle Row -->
+    <div class="columns mb-4">
+        <div class="column is-half">
+            <div class="field">
+                <label class="label">Status</label>
+                <div class="control">
+                    <div class="select is-fullwidth">
+                        <select x-model="formData.status">
+                            <option value="open">Open</option>
+                            <option value="waiting">Waiting</option>
+                            <option value="deferred">Deferred</option>
+                            <option value="declined">Declined</option>
+                            <option value="stale">Stale</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="column is-half">
+            <div class="field">
+                <label class="label">Active Status</label>
+                <div class="control">
+                    <label class="checkbox">
+                        <input type="checkbox" x-model="formData.active">
+                        <span class="ml-2">Active (in working set)</span>
+                    </label>
+                    <p class="help">Uncheck to move to someday/maybe</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tags Section (Placeholder) -->
+    <div class="field mb-4">
+        <label class="label">
+            <span class="icon-text">
+                <span class="icon">
+                    <i class="fas fa-tags"></i>
+                </span>
+                <span>Tags</span>
+            </span>
+        </label>
+        <div class="box has-background-light">
+            <p class="has-text-grey-dark">
+                <span class="icon">
+                    <i class="fas fa-info-circle"></i>
+                </span>
+                Tag management coming soon
+            </p>
+        </div>
+    </div>
+
+    <!-- Principles Section (Placeholder) -->
+    <div class="field mb-4">
+        <label class="label">
+            <span class="icon-text">
+                <span class="icon">
+                    <i class="fas fa-compass"></i>
+                </span>
+                <span>Principles</span>
+            </span>
+        </label>
+        <div class="box has-background-light">
+            <p class="has-text-grey-dark">
+                <span class="icon">
+                    <i class="fas fa-info-circle"></i>
+                </span>
+                Principle management coming soon
+            </p>
+        </div>
+    </div>
+
+    <!-- Action Buttons -->
+    <div class="field is-grouped is-grouped-right">
+        <div class="control">
+            <button class="button" @click="cancel()">
+                <span class="icon">
+                    <i class="fas fa-times"></i>
+                </span>
+                <span>Cancel</span>
+            </button>
+        </div>
+        <div class="control">
+            <button class="button is-primary"
+                    @click="create()"
+                    :class="{ 'is-loading': saving }"
+                    :disabled="saving">
+                <span class="icon">
+                    <i class="fas fa-plus"></i>
+                </span>
+                <span>Create Task</span>
+            </button>
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/src/webapp/templates/components/tasks/task_edit.html
+++ b/src/webapp/templates/components/tasks/task_edit.html
@@ -1,0 +1,187 @@
+{# Task Edit Component - Editable form for modifying a task #}
+
+{% macro task_edit(task) %}
+<div x-data='taskEdit({{ task | tojson }})' class="box">
+    <!-- Header with Title Input -->
+    <div class="field mb-4">
+        <label class="label">Task Title</label>
+        <div class="control">
+            <input class="input"
+                   type="text"
+                   x-model="formData.title"
+                   placeholder="Enter task title"
+                   :class="{ 'is-danger': errors.title }">
+        </div>
+        <p class="help is-danger" x-show="errors.title" x-text="errors.title"></p>
+    </div>
+
+    <!-- Description -->
+    <div class="field mb-4">
+        <label class="label">Description</label>
+        <div class="control">
+            <textarea class="textarea"
+                      x-model="formData.description"
+                      placeholder="Add details about this task (optional)"
+                      rows="4"></textarea>
+        </div>
+    </div>
+
+    <!-- Status and Active Toggle Row -->
+    <div class="columns mb-4">
+        <div class="column is-half">
+            <div class="field">
+                <label class="label">Status</label>
+                <div class="control">
+                    <div class="select is-fullwidth">
+                        <select x-model="formData.status">
+                            <option value="open">Open</option>
+                            <option value="waiting">Waiting</option>
+                            <option value="deferred">Deferred</option>
+                            <option value="declined">Declined</option>
+                            <option value="stale">Stale</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="column is-half">
+            <div class="field">
+                <label class="label">Active Status</label>
+                <div class="control">
+                    <label class="checkbox">
+                        <input type="checkbox" x-model="formData.active">
+                        <span class="ml-2">Active (in working set)</span>
+                    </label>
+                    <p class="help">Uncheck to move to someday/maybe</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Project Association (Read-only for now) -->
+    <div class="field mb-4" x-show="task.project_id">
+        <label class="label">Project</label>
+        <div class="box has-background-light">
+            <span class="icon-text">
+                <span class="icon has-text-link">
+                    <i class="fas fa-folder"></i>
+                </span>
+                <span>This task is a subtask of Project #<span x-text="task.project_id"></span></span>
+            </span>
+            <p class="help mt-2">Project association cannot be changed from here</p>
+        </div>
+    </div>
+
+    <!-- Tags Section (Placeholder) -->
+    <div class="field mb-4">
+        <label class="label">
+            <span class="icon-text">
+                <span class="icon">
+                    <i class="fas fa-tags"></i>
+                </span>
+                <span>Tags</span>
+            </span>
+        </label>
+        <div class="box has-background-light">
+            <p class="has-text-grey-dark">
+                <span class="icon">
+                    <i class="fas fa-info-circle"></i>
+                </span>
+                Tag management coming soon
+            </p>
+        </div>
+    </div>
+
+    <!-- Principles Section (Placeholder) -->
+    <div class="field mb-4">
+        <label class="label">
+            <span class="icon-text">
+                <span class="icon">
+                    <i class="fas fa-compass"></i>
+                </span>
+                <span>Principles</span>
+            </span>
+        </label>
+        <div class="box has-background-light">
+            <p class="has-text-grey-dark">
+                <span class="icon">
+                    <i class="fas fa-info-circle"></i>
+                </span>
+                Principle management coming soon
+            </p>
+        </div>
+    </div>
+
+    <!-- Metadata (Read-only) -->
+    <div class="box has-background-white-bis mb-4">
+        <p class="heading">Metadata</p>
+        <div class="is-size-7 has-text-grey">
+            <p class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-hashtag"></i>
+                </span>
+                ID: <span x-text="task.id"></span>
+            </p>
+            <p class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-plus"></i>
+                </span>
+                Created: <span x-text="formatDate(task.created_at)"></span>
+            </p>
+            <p class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-edit"></i>
+                </span>
+                Last Updated: <span x-text="formatDate(task.updated_at)"></span>
+            </p>
+            <p x-show="task.completed" class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-check-circle"></i>
+                </span>
+                Completed: <span x-text="formatDate(task.completed_at)"></span>
+            </p>
+        </div>
+    </div>
+
+    <!-- Action Buttons -->
+    <div class="field is-grouped is-grouped-right">
+        <div class="control">
+            <button class="button" @click="cancel()">
+                <span class="icon">
+                    <i class="fas fa-times"></i>
+                </span>
+                <span>Cancel</span>
+            </button>
+        </div>
+        <div class="control">
+            <button class="button is-primary"
+                    @click="save()"
+                    :class="{ 'is-loading': saving }"
+                    :disabled="saving">
+                <span class="icon">
+                    <i class="fas fa-save"></i>
+                </span>
+                <span>Save Changes</span>
+            </button>
+        </div>
+    </div>
+
+    <!-- Danger Zone -->
+    <hr>
+    <div class="has-background-danger-light p-4" style="border-radius: 6px;">
+        <p class="heading has-text-danger">Danger Zone</p>
+        <div class="is-flex is-justify-content-space-between is-align-items-center">
+            <div>
+                <p class="has-text-weight-semibold">Delete this task</p>
+                <p class="is-size-7 has-text-grey-dark">This action cannot be undone</p>
+            </div>
+            <button class="button is-danger" @click="deleteTask()">
+                <span class="icon">
+                    <i class="fas fa-trash"></i>
+                </span>
+                <span>Delete</span>
+            </button>
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/src/webapp/templates/components/tasks/task_item.html
+++ b/src/webapp/templates/components/tasks/task_item.html
@@ -1,0 +1,163 @@
+{# Task Item Component - Reusable macro for displaying a task with minimized and expanded states #}
+
+{% macro task_item(task) %}
+<div x-data='taskItem({{ task | tojson }})' class="mb-4">
+    <!-- Minimized State -->
+    <div x-show="!expanded"
+         @click="toggle()"
+         class="box is-clickable"
+         :class="{ 'has-background-success-light': task.completed, 'opacity-70': !task.active && !task.completed }"
+         style="cursor: pointer;">
+        <div class="is-flex is-align-items-center is-justify-content-space-between">
+            <div class="is-flex is-align-items-center" style="flex: 1;">
+                <!-- Status Indicator -->
+                <span class="icon" :class="task.completed ? 'has-text-success' : getStatusColor()">
+                    <i class="fas" :class="task.completed ? 'fa-check-circle' : 'fa-circle'" :style="task.completed ? '' : 'font-size: 0.5rem;'"></i>
+                </span>
+                <!-- Title -->
+                <span class="ml-2"
+                      :class="task.completed ? 'has-text-grey-light' : ''"
+                      :style="task.completed ? 'text-decoration: line-through;' : ''"
+                      x-text="task.title"></span>
+            </div>
+            <!-- Badges -->
+            <div class="is-flex is-align-items-center">
+                <span x-show="task.completed" class="tag is-success">Completed</span>
+                <span x-show="task.project_id && !task.completed" class="tag is-link is-light mr-2">
+                    <span class="icon is-small">
+                        <i class="fas fa-folder"></i>
+                    </span>
+                    <span>Subtask</span>
+                </span>
+                <span x-show="!task.active && !task.completed" class="tag is-warning is-light mr-2">
+                    Someday/Maybe
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Expanded State -->
+    <div x-show="expanded"
+         class="box"
+         :class="{ 'has-background-success-light': task.completed }">
+        <div class="is-flex is-justify-content-space-between is-align-items-start mb-3">
+            <h3 class="title is-5 mb-0" x-text="task.title"></h3>
+            <button @click="toggle()" class="delete"></button>
+        </div>
+
+        <!-- Status and Metadata Bar -->
+        <div class="is-flex is-flex-wrap-wrap mb-3" style="gap: 0.5rem;">
+            <span class="tag" :class="getStatusTagClass()" x-text="task.status"></span>
+            <span x-show="task.project_id" class="tag is-link is-light">
+                <span class="icon is-small">
+                    <i class="fas fa-folder"></i>
+                </span>
+                <span>Subtask</span>
+            </span>
+            <span x-show="!task.active" class="tag is-warning is-light">Someday/Maybe</span>
+            <span x-show="task.completed" class="tag is-success">
+                <span class="icon is-small">
+                    <i class="fas fa-check"></i>
+                </span>
+                <span>Completed</span>
+            </span>
+        </div>
+
+        <!-- Description -->
+        <div x-show="task.description" class="content mb-3">
+            <p x-text="task.description"></p>
+        </div>
+
+        <!-- Timestamps -->
+        <div class="is-size-7 has-text-grey">
+            <p class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-plus"></i>
+                </span>
+                Created: <span x-text="formatDate(task.created_at)"></span>
+            </p>
+            <p class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-edit"></i>
+                </span>
+                Updated: <span x-text="formatDate(task.updated_at)"></span>
+            </p>
+            <p x-show="task.completed_at" class="mb-1">
+                <span class="icon is-small">
+                    <i class="fas fa-check-circle"></i>
+                </span>
+                Completed: <span x-text="formatDate(task.completed_at)"></span>
+            </p>
+        </div>
+
+        <!-- Action Buttons -->
+        <div class="buttons mt-4">
+            <!-- Active task buttons -->
+            <template x-if="task.active && !task.completed">
+                <div class="buttons">
+                    <button class="button is-small is-success">
+                        <span class="icon is-small">
+                            <i class="fas fa-check"></i>
+                        </span>
+                        <span>Complete</span>
+                    </button>
+                    <button class="button is-small is-info">
+                        <span class="icon is-small">
+                            <i class="fas fa-edit"></i>
+                        </span>
+                        <span>Edit</span>
+                    </button>
+                    <button class="button is-small is-danger">
+                        <span class="icon is-small">
+                            <i class="fas fa-trash"></i>
+                        </span>
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </template>
+
+            <!-- Completed task buttons -->
+            <template x-if="task.completed">
+                <div class="buttons">
+                    <button class="button is-small is-warning">
+                        <span class="icon is-small">
+                            <i class="fas fa-undo"></i>
+                        </span>
+                        <span>Uncomplete</span>
+                    </button>
+                    <button class="button is-small is-danger">
+                        <span class="icon is-small">
+                            <i class="fas fa-trash"></i>
+                        </span>
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </template>
+
+            <!-- Inactive (someday/maybe) task buttons -->
+            <template x-if="!task.active && !task.completed">
+                <div class="buttons">
+                    <button class="button is-small is-primary">
+                        <span class="icon is-small">
+                            <i class="fas fa-play"></i>
+                        </span>
+                        <span>Activate</span>
+                    </button>
+                    <button class="button is-small is-info">
+                        <span class="icon is-small">
+                            <i class="fas fa-edit"></i>
+                        </span>
+                        <span>Edit</span>
+                    </button>
+                    <button class="button is-small is-danger">
+                        <span class="icon is-small">
+                            <i class="fas fa-trash"></i>
+                        </span>
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </template>
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/src/webapp/templates/components/tasks/task_manager.html
+++ b/src/webapp/templates/components/tasks/task_manager.html
@@ -1,0 +1,353 @@
+{# Task Manager Component - Wrapper that handles view/edit mode switching for a task #}
+
+{% macro task_manager(task) %}
+<div x-data='taskManager({{ task | tojson }})' class="mb-4">
+    <!-- View Mode: Display the task -->
+    <template x-if="mode === 'view'">
+        <div>
+            <!-- Minimized State -->
+            <div x-show="!expanded"
+                 @click="toggleExpand()"
+                 class="box is-clickable"
+                 :class="{ 'has-background-success-light': task.completed, 'opacity-70': !task.active && !task.completed }"
+                 style="cursor: pointer;">
+                <div class="is-flex is-align-items-center is-justify-content-space-between">
+                    <div class="is-flex is-align-items-center" style="flex: 1;">
+                        <!-- Status Indicator -->
+                        <span class="icon" :class="task.completed ? 'has-text-success' : getStatusColor()">
+                            <i class="fas" :class="task.completed ? 'fa-check-circle' : 'fa-circle'" :style="task.completed ? '' : 'font-size: 0.5rem;'"></i>
+                        </span>
+                        <!-- Title -->
+                        <span class="ml-2"
+                              :class="task.completed ? 'has-text-grey-light' : ''"
+                              :style="task.completed ? 'text-decoration: line-through;' : ''"
+                              x-text="task.title"></span>
+                    </div>
+                    <!-- Badges -->
+                    <div class="is-flex is-align-items-center">
+                        <span x-show="task.completed" class="tag is-success">Completed</span>
+                        <span x-show="task.project_id && !task.completed" class="tag is-link is-light mr-2">
+                            <span class="icon is-small">
+                                <i class="fas fa-folder"></i>
+                            </span>
+                            <span>Subtask</span>
+                        </span>
+                        <span x-show="!task.active && !task.completed" class="tag is-warning is-light mr-2">
+                            Someday/Maybe
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Expanded State -->
+            <div x-show="expanded" class="box" :class="{ 'has-background-success-light': task.completed }">
+                <div class="is-flex is-justify-content-space-between is-align-items-start mb-3">
+                    <h3 class="title is-5 mb-0" x-text="task.title"></h3>
+                    <button @click="toggleExpand()" class="delete"></button>
+                </div>
+
+                <!-- Status and Metadata Bar -->
+                <div class="is-flex is-flex-wrap-wrap mb-3" style="gap: 0.5rem;">
+                    <span class="tag" :class="getStatusTagClass()" x-text="task.status"></span>
+                    <span x-show="task.project_id" class="tag is-link is-light">
+                        <span class="icon is-small">
+                            <i class="fas fa-folder"></i>
+                        </span>
+                        <span>Subtask</span>
+                    </span>
+                    <span x-show="!task.active" class="tag is-warning is-light">Someday/Maybe</span>
+                    <span x-show="task.completed" class="tag is-success">
+                        <span class="icon is-small">
+                            <i class="fas fa-check"></i>
+                        </span>
+                        <span>Completed</span>
+                    </span>
+                </div>
+
+                <!-- Description -->
+                <div x-show="task.description" class="content mb-3">
+                    <p x-text="task.description"></p>
+                </div>
+
+                <!-- Timestamps -->
+                <div class="is-size-7 has-text-grey">
+                    <p class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-plus"></i>
+                        </span>
+                        Created: <span x-text="formatDate(task.created_at)"></span>
+                    </p>
+                    <p class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-edit"></i>
+                        </span>
+                        Updated: <span x-text="formatDate(task.updated_at)"></span>
+                    </p>
+                    <p x-show="task.completed_at" class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-check-circle"></i>
+                        </span>
+                        Completed: <span x-text="formatDate(task.completed_at)"></span>
+                    </p>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="buttons mt-4">
+                    <!-- Active task buttons -->
+                    <template x-if="task.active && !task.completed">
+                        <div class="buttons">
+                            <button class="button is-small is-success">
+                                <span class="icon is-small">
+                                    <i class="fas fa-check"></i>
+                                </span>
+                                <span>Complete</span>
+                            </button>
+                            <button class="button is-small is-info" @click="edit()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-edit"></i>
+                                </span>
+                                <span>Edit</span>
+                            </button>
+                            <button class="button is-small is-danger" @click="deleteTask()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-trash"></i>
+                                </span>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                    </template>
+
+                    <!-- Completed task buttons -->
+                    <template x-if="task.completed">
+                        <div class="buttons">
+                            <button class="button is-small is-warning">
+                                <span class="icon is-small">
+                                    <i class="fas fa-undo"></i>
+                                </span>
+                                <span>Uncomplete</span>
+                            </button>
+                            <button class="button is-small is-danger" @click="deleteTask()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-trash"></i>
+                                </span>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                    </template>
+
+                    <!-- Inactive (someday/maybe) task buttons -->
+                    <template x-if="!task.active && !task.completed">
+                        <div class="buttons">
+                            <button class="button is-small is-primary">
+                                <span class="icon is-small">
+                                    <i class="fas fa-play"></i>
+                                </span>
+                                <span>Activate</span>
+                            </button>
+                            <button class="button is-small is-info" @click="edit()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-edit"></i>
+                                </span>
+                                <span>Edit</span>
+                            </button>
+                            <button class="button is-small is-danger" @click="deleteTask()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-trash"></i>
+                                </span>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <!-- Edit Mode: Show the edit form -->
+    <template x-if="mode === 'edit'">
+        <div class="box">
+            <!-- Header with Title Input -->
+            <div class="field mb-4">
+                <label class="label">Task Title *</label>
+                <div class="control">
+                    <input class="input"
+                           type="text"
+                           x-model="formData.title"
+                           placeholder="Enter task title"
+                           :class="{ 'is-danger': errors.title }">
+                </div>
+                <p class="help is-danger" x-show="errors.title" x-text="errors.title"></p>
+            </div>
+
+            <!-- Description -->
+            <div class="field mb-4">
+                <label class="label">Description</label>
+                <div class="control">
+                    <textarea class="textarea"
+                              x-model="formData.description"
+                              placeholder="Add details about this task (optional)"
+                              rows="4"></textarea>
+                </div>
+            </div>
+
+            <!-- Status and Active Toggle Row -->
+            <div class="columns mb-4">
+                <div class="column is-half">
+                    <div class="field">
+                        <label class="label">Status</label>
+                        <div class="control">
+                            <div class="select is-fullwidth">
+                                <select x-model="formData.status">
+                                    <option value="open">Open</option>
+                                    <option value="waiting">Waiting</option>
+                                    <option value="deferred">Deferred</option>
+                                    <option value="declined">Declined</option>
+                                    <option value="stale">Stale</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-half">
+                    <div class="field">
+                        <label class="label">Active Status</label>
+                        <div class="control">
+                            <label class="checkbox">
+                                <input type="checkbox" x-model="formData.active">
+                                <span class="ml-2">Active (in working set)</span>
+                            </label>
+                            <p class="help">Uncheck to move to someday/maybe</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Project Association (Read-only) -->
+            <div class="field mb-4" x-show="task.project_id">
+                <label class="label">Project</label>
+                <div class="box has-background-light">
+                    <span class="icon-text">
+                        <span class="icon has-text-link">
+                            <i class="fas fa-folder"></i>
+                        </span>
+                        <span>This task is a subtask of Project #<span x-text="task.project_id"></span></span>
+                    </span>
+                    <p class="help mt-2">Project association cannot be changed from here</p>
+                </div>
+            </div>
+
+            <!-- Tags Section (Placeholder) -->
+            <div class="field mb-4">
+                <label class="label">
+                    <span class="icon-text">
+                        <span class="icon">
+                            <i class="fas fa-tags"></i>
+                        </span>
+                        <span>Tags</span>
+                    </span>
+                </label>
+                <div class="box has-background-light">
+                    <p class="has-text-grey-dark">
+                        <span class="icon">
+                            <i class="fas fa-info-circle"></i>
+                        </span>
+                        Tag management coming soon
+                    </p>
+                </div>
+            </div>
+
+            <!-- Principles Section (Placeholder) -->
+            <div class="field mb-4">
+                <label class="label">
+                    <span class="icon-text">
+                        <span class="icon">
+                            <i class="fas fa-compass"></i>
+                        </span>
+                        <span>Principles</span>
+                    </span>
+                </label>
+                <div class="box has-background-light">
+                    <p class="has-text-grey-dark">
+                        <span class="icon">
+                            <i class="fas fa-info-circle"></i>
+                        </span>
+                        Principle management coming soon
+                    </p>
+                </div>
+            </div>
+
+            <!-- Metadata (Read-only) -->
+            <div class="box has-background-white-bis mb-4">
+                <p class="heading">Metadata</p>
+                <div class="is-size-7 has-text-grey">
+                    <p class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-hashtag"></i>
+                        </span>
+                        ID: <span x-text="task.id"></span>
+                    </p>
+                    <p class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-plus"></i>
+                        </span>
+                        Created: <span x-text="formatDate(task.created_at)"></span>
+                    </p>
+                    <p class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-edit"></i>
+                        </span>
+                        Last Updated: <span x-text="formatDate(task.updated_at)"></span>
+                    </p>
+                    <p x-show="task.completed" class="mb-1">
+                        <span class="icon is-small">
+                            <i class="fas fa-check-circle"></i>
+                        </span>
+                        Completed: <span x-text="formatDate(task.completed_at)"></span>
+                    </p>
+                </div>
+            </div>
+
+            <!-- Action Buttons -->
+            <div class="field is-grouped is-grouped-right">
+                <div class="control">
+                    <button class="button" @click="cancelEdit()">
+                        <span class="icon">
+                            <i class="fas fa-times"></i>
+                        </span>
+                        <span>Cancel</span>
+                    </button>
+                </div>
+                <div class="control">
+                    <button class="button is-primary"
+                            @click="save()"
+                            :class="{ 'is-loading': saving }"
+                            :disabled="saving">
+                        <span class="icon">
+                            <i class="fas fa-save"></i>
+                        </span>
+                        <span>Save Changes</span>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Danger Zone -->
+            <hr>
+            <div class="has-background-danger-light p-4" style="border-radius: 6px;">
+                <p class="heading has-text-danger">Danger Zone</p>
+                <div class="is-flex is-justify-content-space-between is-align-items-center">
+                    <div>
+                        <p class="has-text-weight-semibold">Delete this task</p>
+                        <p class="is-size-7 has-text-grey-dark">This action cannot be undone</p>
+                    </div>
+                    <button class="button is-danger" @click="deleteTask()">
+                        <span class="icon">
+                            <i class="fas fa-trash"></i>
+                        </span>
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </template>
+</div>
+{% endmacro %}

--- a/src/webapp/templates/components/tasks/task_search.html
+++ b/src/webapp/templates/components/tasks/task_search.html
@@ -1,0 +1,238 @@
+{# Task Search Component - Collapsible search and filter interface #}
+
+{% macro task_search() %}
+<div x-data='taskSearch()' class="mb-4">
+    <!-- Collapsed State: Simple search box -->
+    <div x-show="!expanded" class="box">
+        <div class="field has-addons">
+            <div class="control is-expanded has-icons-left">
+                <input class="input"
+                       type="text"
+                       x-model="simpleSearch"
+                       @keyup.enter="applySimpleSearch()"
+                       placeholder="Search tasks...">
+                <span class="icon is-small is-left">
+                    <i class="fas fa-search"></i>
+                </span>
+            </div>
+            <div class="control">
+                <button class="button is-info" @click="expand()">
+                    <span class="icon">
+                        <i class="fas fa-filter"></i>
+                    </span>
+                    <span>Advanced</span>
+                </button>
+            </div>
+            <div class="control">
+                <button class="button" @click="applySimpleSearch()">
+                    <span class="icon">
+                        <i class="fas fa-search"></i>
+                    </span>
+                </button>
+            </div>
+        </div>
+
+        <!-- Active filters display -->
+        <div x-show="hasActiveFilters()" class="tags mt-3">
+            <span class="tag is-info is-light">
+                <span x-text="getActiveFilterCount()"></span> filter(s) active
+            </span>
+            <button class="tag is-delete" @click="clearFilters()"></button>
+        </div>
+    </div>
+
+    <!-- Expanded State: Advanced filters -->
+    <div x-show="expanded" class="box">
+        <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
+            <h3 class="title is-5 mb-0">Search & Filter Tasks</h3>
+            <button @click="collapse()" class="delete"></button>
+        </div>
+
+        <!-- Title Search -->
+        <div class="field mb-4">
+            <label class="label">Title</label>
+            <div class="control has-icons-left">
+                <input class="input"
+                       type="text"
+                       x-model="filters.title"
+                       placeholder="Search in task titles...">
+                <span class="icon is-small is-left">
+                    <i class="fas fa-heading"></i>
+                </span>
+            </div>
+        </div>
+
+        <!-- Description Search -->
+        <div class="field mb-4">
+            <label class="label">Description</label>
+            <div class="control has-icons-left">
+                <input class="input"
+                       type="text"
+                       x-model="filters.description"
+                       placeholder="Search in task descriptions...">
+                <span class="icon is-small is-left">
+                    <i class="fas fa-align-left"></i>
+                </span>
+            </div>
+        </div>
+
+        <!-- Status Filter -->
+        <div class="field mb-4">
+            <label class="label">Status</label>
+            <div class="control">
+                <div class="field is-grouped is-grouped-multiline">
+                    <div class="control">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="filters.status.open">
+                            <span class="ml-2">Open</span>
+                        </label>
+                    </div>
+                    <div class="control">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="filters.status.waiting">
+                            <span class="ml-2">Waiting</span>
+                        </label>
+                    </div>
+                    <div class="control">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="filters.status.deferred">
+                            <span class="ml-2">Deferred</span>
+                        </label>
+                    </div>
+                    <div class="control">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="filters.status.declined">
+                            <span class="ml-2">Declined</span>
+                        </label>
+                    </div>
+                    <div class="control">
+                        <label class="checkbox">
+                            <input type="checkbox" x-model="filters.status.stale">
+                            <span class="ml-2">Stale</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Active Status Filter -->
+        <div class="field mb-4">
+            <label class="label">Active Status</label>
+            <div class="control">
+                <label class="radio">
+                    <input type="radio" x-model="filters.activeStatus" value="active">
+                    Active only
+                </label>
+                <label class="radio ml-4">
+                    <input type="radio" x-model="filters.activeStatus" value="all">
+                    All
+                </label>
+                <label class="radio ml-4">
+                    <input type="radio" x-model="filters.activeStatus" value="inactive">
+                    Someday/Maybe only
+                </label>
+            </div>
+            <p class="help">Filter by whether tasks are in your active working set</p>
+        </div>
+
+        <!-- Completion Status Filter -->
+        <div class="field mb-4">
+            <label class="label">Completion Status</label>
+            <div class="control">
+                <label class="radio">
+                    <input type="radio" x-model="filters.completionStatus" value="incomplete">
+                    Incomplete only
+                </label>
+                <label class="radio ml-4">
+                    <input type="radio" x-model="filters.completionStatus" value="all">
+                    All
+                </label>
+                <label class="radio ml-4">
+                    <input type="radio" x-model="filters.completionStatus" value="complete">
+                    Completed only
+                </label>
+            </div>
+        </div>
+
+        <!-- Project Filter (Placeholder) -->
+        <div class="field mb-4">
+            <label class="label">
+                <span class="icon-text">
+                    <span class="icon">
+                        <i class="fas fa-folder"></i>
+                    </span>
+                    <span>Project</span>
+                </span>
+            </label>
+            <div class="box has-background-light">
+                <p class="has-text-grey-dark">
+                    <span class="icon">
+                        <i class="fas fa-info-circle"></i>
+                    </span>
+                    Project filtering coming soon
+                </p>
+            </div>
+        </div>
+
+        <!-- Tags Filter (Placeholder) -->
+        <div class="field mb-4">
+            <label class="label">
+                <span class="icon-text">
+                    <span class="icon">
+                        <i class="fas fa-tags"></i>
+                    </span>
+                    <span>Tags</span>
+                </span>
+            </label>
+            <div class="box has-background-light">
+                <p class="has-text-grey-dark">
+                    <span class="icon">
+                        <i class="fas fa-info-circle"></i>
+                    </span>
+                    Tag filtering coming soon
+                </p>
+            </div>
+        </div>
+
+        <!-- Principles Filter (Placeholder) -->
+        <div class="field mb-4">
+            <label class="label">
+                <span class="icon-text">
+                    <span class="icon">
+                        <i class="fas fa-compass"></i>
+                    </span>
+                    <span>Principles</span>
+                </span>
+            </label>
+            <div class="box has-background-light">
+                <p class="has-text-grey-dark">
+                    <span class="icon">
+                        <i class="fas fa-info-circle"></i>
+                    </span>
+                    Principle filtering coming soon
+                </p>
+            </div>
+        </div>
+
+        <!-- Action Buttons -->
+        <div class="field is-grouped is-grouped-right">
+            <div class="control">
+                <button class="button" @click="clearFilters()">
+                    <span class="icon">
+                        <i class="fas fa-times"></i>
+                    </span>
+                    <span>Clear Filters</span>
+                </button>
+            </div>
+            <div class="control">
+                <button class="button is-primary" @click="applyFilters()">
+                    <span class="icon">
+                        <i class="fas fa-search"></i>
+                    </span>
+                    <span>Apply Filters</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/src/webapp/templates/pages/component_demo/task_component_demo.html
+++ b/src/webapp/templates/pages/component_demo/task_component_demo.html
@@ -1,0 +1,523 @@
+{% extends "base.html" %}
+{% from "components/tasks/task_manager.html" import task_manager %}
+{% from "components/tasks/task_create.html" import task_create %}
+{% from "components/tasks/task_search.html" import task_search %}
+
+{% block title %}Task Component Demo{% endblock %}
+
+{% block content %}
+<section class="section">
+    <div class="container">
+        <h1 class="title">Task Component Demo</h1>
+        <p class="subtitle">UI component testing and demonstration</p>
+
+        <!-- Search Component Demo -->
+        <div class="box mb-6">
+            <h2 class="title is-4">Search & Filter Component</h2>
+            <p class="subtitle is-6">Simple search box that expands to show advanced filters</p>
+            
+            {{ task_search() }}
+        </div>
+
+        <!-- Create Task Section -->
+        <div class="box mb-6">
+            <h2 class="title is-4">Create Task Flow</h2>
+            <p class="subtitle is-6">Create a new task - after saving it will appear as a task item below</p>
+            
+            <div x-data="taskCreateManager()">
+                <!-- Show create form or created task -->
+                <template x-if="!createdTask">
+                    <div>
+                        {{ task_create() }}
+                    </div>
+                </template>
+                
+                <template x-if="createdTask">
+                    <div>
+                        <div class="notification is-success is-light mb-4">
+                            <button class="delete" @click="reset()"></button>
+                            Task created successfully! This is how it appears as a task item. Click the X to create another task.
+                        </div>
+                        
+                        <!-- Show the created task using task_manager -->
+                        <div x-data='taskManager(createdTask)'>
+                            <!-- Just show the view without the manager wrapper for demo purposes -->
+                            <div class="box" :class="{ 'has-background-success-light': createdTask.completed }">
+                                <div class="is-flex is-justify-content-space-between is-align-items-start mb-3">
+                                    <h3 class="title is-5 mb-0" x-text="createdTask.title"></h3>
+                                </div>
+
+                                <div class="is-flex is-flex-wrap-wrap mb-3" style="gap: 0.5rem;">
+                                    <span class="tag" :class="getStatusTagClass()" x-text="createdTask.status"></span>
+                                    <span x-show="!createdTask.active" class="tag is-warning is-light">Someday/Maybe</span>
+                                </div>
+
+                                <div x-show="createdTask.description" class="content mb-3">
+                                    <p x-text="createdTask.description"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+
+        <!-- Task Item Component Demo -->
+        <div class="box">
+            <h2 class="title is-4">Task Item Component (View/Edit Flow)</h2>
+            <p class="subtitle is-6">Click tasks to expand, then click "Edit" to modify them</p>
+
+            <div class="content">
+                <!-- Task Item 1: Active, Open, Standalone -->
+                {{ task_manager({
+                    'id': 1,
+                    'title': 'Buy new running shoes',
+                    'description': 'Need to replace my current pair - they have about 500 miles on them. Look for something with good arch support.',
+                    'status': 'open',
+                    'active': true,
+                    'completed': false,
+                    'project_id': none,
+                    'created_at': '2026-04-10T14:30:00',
+                    'updated_at': '2026-04-12T09:15:00'
+                }) }}
+
+                <!-- Task Item 2: Waiting, Has Description -->
+                {{ task_manager({
+                    'id': 2,
+                    'title': 'Reply to email from Sarah about project proposal',
+                    'description': 'Sarah sent over feedback on sections 2-4. Need to address her concerns about the timeline and budget estimates.',
+                    'status': 'waiting',
+                    'active': true,
+                    'completed': false,
+                    'project_id': none,
+                    'created_at': '2026-04-13T10:00:00',
+                    'updated_at': '2026-04-14T16:30:00'
+                }) }}
+
+                <!-- Task Item 3: Completed -->
+                {{ task_manager({
+                    'id': 3,
+                    'title': 'Review Q1 budget report',
+                    'description': none,
+                    'status': 'open',
+                    'active': true,
+                    'completed': true,
+                    'completed_at': '2026-04-14T11:00:00',
+                    'project_id': none,
+                    'created_at': '2026-04-09T08:00:00',
+                    'updated_at': '2026-04-14T11:00:00'
+                }) }}
+
+                <!-- Task Item 4: Subtask of a Project -->
+                {{ task_manager({
+                    'id': 4,
+                    'title': 'Draft introduction section',
+                    'description': 'Write the first draft of the introduction covering background and motivation.',
+                    'status': 'open',
+                    'active': true,
+                    'completed': false,
+                    'project_id': 42,
+                    'created_at': '2026-04-11T09:00:00',
+                    'updated_at': '2026-04-11T09:00:00'
+                }) }}
+
+                <!-- Task Item 5: Someday/Maybe -->
+                {{ task_manager({
+                    'id': 5,
+                    'title': 'Learn to play guitar',
+                    'description': 'Would be nice to learn someday. Maybe take a few lessons or use an online course.',
+                    'status': 'deferred',
+                    'active': false,
+                    'completed': false,
+                    'project_id': none,
+                    'created_at': '2026-03-15T12:00:00',
+                    'updated_at': '2026-03-15T12:00:00'
+                }) }}
+            </div>
+        </div>
+
+    </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    // Task Manager - Handles view/edit mode switching for existing tasks
+    function taskManager(initialTask) {
+        return {
+            task: initialTask,
+            mode: 'view',
+            expanded: false,
+            formData: {},
+            errors: {},
+            saving: false,
+
+            edit() {
+                this.formData = {
+                    title: this.task.title,
+                    description: this.task.description,
+                    status: this.task.status,
+                    active: this.task.active
+                };
+                this.mode = 'edit';
+                this.expanded = true;
+            },
+
+            toggleExpand() {
+                this.expanded = !this.expanded;
+            },
+
+            validate() {
+                this.errors = {};
+                
+                if (!this.formData.title || this.formData.title.trim() === '') {
+                    this.errors.title = 'Title is required';
+                    return false;
+                }
+                
+                if (this.formData.title.length > 200) {
+                    this.errors.title = 'Title must be 200 characters or less';
+                    return false;
+                }
+                
+                return true;
+            },
+
+            async save() {
+                if (!this.validate()) {
+                    return;
+                }
+
+                this.saving = true;
+                
+                try {
+                    // TODO: Replace with actual API call
+                    // const result = await api.patch(`/api/tasks/${this.task.id}`, this.formData);
+                    
+                    // Simulate API call
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                    
+                    console.log('Saving task:', this.formData);
+                    
+                    // Update task with new values
+                    this.task.title = this.formData.title;
+                    this.task.description = this.formData.description;
+                    this.task.status = this.formData.status;
+                    this.task.active = this.formData.active;
+                    this.task.updated_at = new Date().toISOString();
+                    
+                    // Switch back to view mode
+                    this.mode = 'view';
+                    
+                } catch (err) {
+                    console.error('Error saving task:', err);
+                    alert('Error saving task: ' + err.message);
+                } finally {
+                    this.saving = false;
+                }
+            },
+
+            cancelEdit() {
+                this.formData = {};
+                this.errors = {};
+                this.mode = 'view';
+            },
+
+            deleteTask() {
+                if (!confirm('Are you sure you want to delete this task? This action cannot be undone.')) {
+                    return;
+                }
+                
+                // TODO: Replace with actual API call
+                console.log('Deleting task:', this.task.id);
+                alert('Task deleted! (This is a demo - no actual deletion)');
+            },
+
+            getStatusColor() {
+                const statusColors = {
+                    'open': 'has-text-success',
+                    'waiting': 'has-text-warning',
+                    'deferred': 'has-text-info',
+                    'declined': 'has-text-danger',
+                    'stale': 'has-text-grey'
+                };
+                return statusColors[this.task.status] || 'has-text-grey';
+            },
+
+            getStatusTagClass() {
+                const statusClasses = {
+                    'open': 'is-success is-light',
+                    'waiting': 'is-warning is-light',
+                    'deferred': 'is-info is-light',
+                    'declined': 'is-danger is-light',
+                    'stale': 'is-light'
+                };
+                return statusClasses[this.task.status] || 'is-light';
+            },
+
+            formatDate(dateString) {
+                if (!dateString) return '';
+                const date = new Date(dateString);
+                return date.toLocaleString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit'
+                });
+            }
+        };
+    }
+
+    // Task Create - Handles creating new tasks
+    function taskCreate() {
+        return {
+            formData: {
+                title: '',
+                description: '',
+                status: 'open',
+                active: true
+            },
+            errors: {},
+            saving: false,
+
+            validate() {
+                this.errors = {};
+                
+                if (!this.formData.title || this.formData.title.trim() === '') {
+                    this.errors.title = 'Title is required';
+                    return false;
+                }
+                
+                if (this.formData.title.length > 200) {
+                    this.errors.title = 'Title must be 200 characters or less';
+                    return false;
+                }
+                
+                return true;
+            },
+
+            async create() {
+                if (!this.validate()) {
+                    return;
+                }
+
+                this.saving = true;
+                
+                try {
+                    // TODO: Replace with actual API call
+                    // const result = await api.post('/api/tasks', this.formData);
+                    
+                    // Simulate API call
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                    
+                    console.log('Creating task:', this.formData);
+                    
+                    // Create a mock task object with the form data
+                    const newTask = {
+                        id: Math.floor(Math.random() * 1000), // Mock ID
+                        ...this.formData,
+                        completed: false,
+                        completed_at: null,
+                        project_id: null,
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString()
+                    };
+                    
+                    // Dispatch custom event with the new task
+                    this.$dispatch('task-created', newTask);
+                    
+                    // Reset form
+                    this.formData = {
+                        title: '',
+                        description: '',
+                        status: 'open',
+                        active: true
+                    };
+                    
+                } catch (err) {
+                    console.error('Error creating task:', err);
+                    alert('Error creating task: ' + err.message);
+                } finally {
+                    this.saving = false;
+                }
+            },
+
+            cancel() {
+                this.formData = {
+                    title: '',
+                    description: '',
+                    status: 'open',
+                    active: true
+                };
+                this.errors = {};
+            }
+        };
+    }
+
+    // Task Create Manager - Wraps the create component to show created result
+    function taskCreateManager() {
+        return {
+            createdTask: null,
+
+            init() {
+                // Listen for the task-created custom event
+                this.$el.addEventListener('task-created', (e) => {
+                    this.createdTask = e.detail;
+                });
+            },
+
+            reset() {
+                this.createdTask = null;
+            },
+
+            getStatusTagClass() {
+                if (!this.createdTask) return '';
+                const statusClasses = {
+                    'open': 'is-success is-light',
+                    'waiting': 'is-warning is-light',
+                    'deferred': 'is-info is-light',
+                    'declined': 'is-danger is-light',
+                    'stale': 'is-light'
+                };
+                return statusClasses[this.createdTask.status] || 'is-light';
+            }
+        };
+    }
+
+    // Task Search - Handles search and filtering
+    function taskSearch() {
+        return {
+            expanded: false,
+            simpleSearch: '',
+            filters: {
+                title: '',
+                description: '',
+                status: {
+                    open: false,
+                    waiting: false,
+                    deferred: false,
+                    declined: false,
+                    stale: false
+                },
+                activeStatus: 'all', // 'active', 'all', 'inactive'
+                completionStatus: 'incomplete' // 'incomplete', 'all', 'complete'
+            },
+
+            expand() {
+                // When expanding, split simple search into title field
+                if (this.simpleSearch) {
+                    this.filters.title = this.simpleSearch;
+                }
+                this.expanded = true;
+            },
+
+            collapse() {
+                this.expanded = false;
+            },
+
+            applySimpleSearch() {
+                console.log('Simple search:', this.simpleSearch);
+                // TODO: Trigger search with simpleSearch value
+                // This would search both title and description
+                alert('Searching for: "' + this.simpleSearch + '" (Demo - no actual search)');
+            },
+
+            applyFilters() {
+                console.log('Applying filters:', this.filters);
+                
+                // Build filter summary
+                const summary = this.getFilterSummary();
+                
+                // TODO: Trigger filtered search with filters object
+                alert('Filters applied:\n' + summary + '\n\n(Demo - no actual search)');
+                
+                // Collapse back to simple view
+                this.collapse();
+            },
+
+            clearFilters() {
+                this.simpleSearch = '';
+                this.filters = {
+                    title: '',
+                    description: '',
+                    status: {
+                        open: false,
+                        waiting: false,
+                        deferred: false,
+                        declined: false,
+                        stale: false
+                    },
+                    activeStatus: 'all',
+                    completionStatus: 'incomplete'
+                };
+                
+                console.log('Filters cleared');
+            },
+
+            hasActiveFilters() {
+                // Check if any filters are set
+                if (this.simpleSearch) return true;
+                if (this.filters.title) return true;
+                if (this.filters.description) return true;
+                
+                // Check if any status checkboxes are checked
+                const hasStatusFilter = Object.values(this.filters.status).some(v => v === true);
+                if (hasStatusFilter) return true;
+                
+                // Check if non-default radio options are selected
+                if (this.filters.activeStatus !== 'all') return true;
+                if (this.filters.completionStatus !== 'incomplete') return true;
+                
+                return false;
+            },
+
+            getActiveFilterCount() {
+                let count = 0;
+                
+                if (this.simpleSearch) count++;
+                if (this.filters.title) count++;
+                if (this.filters.description) count++;
+                
+                // Count status filters
+                count += Object.values(this.filters.status).filter(v => v === true).length;
+                
+                if (this.filters.activeStatus !== 'all') count++;
+                if (this.filters.completionStatus !== 'incomplete') count++;
+                
+                return count;
+            },
+
+            getFilterSummary() {
+                const parts = [];
+                
+                if (this.filters.title) {
+                    parts.push('Title contains: "' + this.filters.title + '"');
+                }
+                
+                if (this.filters.description) {
+                    parts.push('Description contains: "' + this.filters.description + '"');
+                }
+                
+                const selectedStatuses = Object.entries(this.filters.status)
+                    .filter(([key, value]) => value === true)
+                    .map(([key, value]) => key);
+                
+                if (selectedStatuses.length > 0) {
+                    parts.push('Status: ' + selectedStatuses.join(', '));
+                }
+                
+                if (this.filters.activeStatus !== 'all') {
+                    parts.push('Active: ' + this.filters.activeStatus);
+                }
+                
+                if (this.filters.completionStatus !== 'incomplete') {
+                    parts.push('Completion: ' + this.filters.completionStatus);
+                }
+                
+                return parts.length > 0 ? parts.join('\n') : 'No filters active';
+            }
+        };
+    }
+</script>
+{% endblock %}

--- a/src/webapp/templates/pages/dashboard.html
+++ b/src/webapp/templates/pages/dashboard.html
@@ -10,17 +10,17 @@
 
         <div class="columns is-multiline">
             <div class="column is-one-third">
-                <div class="box">
+                <div class="box has-background-light" style="opacity: 0.6;">
                     <h2 class="title is-4">
                         <span class="icon-text">
-                            <span class="icon has-text-primary">
+                            <span class="icon has-text-grey">
                                 <i class="fas fa-inbox"></i>
                             </span>
-                            <span>Desk</span>
+                            <span class="has-text-grey">Desk</span>
                         </span>
                     </h2>
-                    <p class="content">Your daily workspace will appear here.</p>
-                    <a href="/desk" class="button is-primary is-light">Go to Desk</a>
+                    <p class="content has-text-grey">Your daily workspace will appear here.</p>
+                    <button class="button is-light" disabled>Coming Soon</button>
                 </div>
             </div>
 
@@ -35,52 +35,52 @@
                         </span>
                     </h2>
                     <p class="content">Manage your tasks and to-dos.</p>
-                    <a href="/tasks" class="button is-info is-light">View Tasks</a>
+                    <a href="/component-demo/tasks" class="button is-info is-light">View Component Demo</a>
                 </div>
             </div>
 
             <div class="column is-one-third">
-                <div class="box">
+                <div class="box has-background-light" style="opacity: 0.6;">
                     <h2 class="title is-4">
                         <span class="icon-text">
-                            <span class="icon has-text-success">
+                            <span class="icon has-text-grey">
                                 <i class="fas fa-folder"></i>
                             </span>
-                            <span>Projects</span>
+                            <span class="has-text-grey">Projects</span>
                         </span>
                     </h2>
-                    <p class="content">Organize tasks into projects.</p>
-                    <a href="/projects" class="button is-success is-light">View Projects</a>
+                    <p class="content has-text-grey">Organize tasks into projects.</p>
+                    <button class="button is-light" disabled>Coming Soon</button>
                 </div>
             </div>
 
             <div class="column is-one-third">
-                <div class="box">
+                <div class="box has-background-light" style="opacity: 0.6;">
                     <h2 class="title is-4">
                         <span class="icon-text">
-                            <span class="icon has-text-warning">
+                            <span class="icon has-text-grey">
                                 <i class="fas fa-repeat"></i>
                             </span>
-                            <span>Routines</span>
+                            <span class="has-text-grey">Routines</span>
                         </span>
                     </h2>
-                    <p class="content">Set up recurring tasks and habits.</p>
-                    <a href="/routines" class="button is-warning is-light">View Routines</a>
+                    <p class="content has-text-grey">Set up recurring tasks and habits.</p>
+                    <button class="button is-light" disabled>Coming Soon</button>
                 </div>
             </div>
 
             <div class="column is-one-third">
-                <div class="box">
+                <div class="box has-background-light" style="opacity: 0.6;">
                     <h2 class="title is-4">
                         <span class="icon-text">
-                            <span class="icon has-text-link">
+                            <span class="icon has-text-grey">
                                 <i class="fas fa-chart-bar"></i>
                             </span>
-                            <span>Reports</span>
+                            <span class="has-text-grey">Reports</span>
                         </span>
                     </h2>
-                    <p class="content">View your productivity insights.</p>
-                    <a href="/reports" class="button is-link is-light">View Reports</a>
+                    <p class="content has-text-grey">View your productivity insights.</p>
+                    <button class="button is-light" disabled>Coming Soon</button>
                 </div>
             </div>
 


### PR DESCRIPTION
We'll be rebuilding the frontend in phases. 
First we'll be building component demo pages, visual representations of the various components using mock data. 

This branch brings the component demo page for tasks. A logged in user will see a button to go to the task component demo page at /component-demo/tasks/ (users who are not logged in can still hit the URL)

The component demo page shows the search&filter component, the create task component, and the task display component (which can toggle between minimized display, maximized display, and edit mode)

All components use mock data, hooking into the API will be another phase of the frontend rebuild.