### PR TITLE
removing gunicorn config

### DIFF
--- a/src/api/gunicorn_config_api.py
+++ b/src/api/gunicorn_config_api.py
@@ -1,8 +1,0 @@
-from src.api.api import app
-from src.database.db import db
-from src.database.config_db import initialize_database
-
-def on_starting(server):
-    with app.app_context():
-        db.create_all()  # This ensures tables exist
-        initialize_database(app)  # This handles any other initialization


### PR DESCRIPTION
Removing a gunicorn config file for the API.

This config file causes a database init function to be run multiple times on startup. Stepping through the code, it looks like the database still initializes without it. 

That will need to be confirmed on staging though; and the systemd service file will need to be modified to remove the flag to use the gunicorn config. 