### PR TITLE
Webap auth tests

### DIFF
--- a/infrastructure/jenkins_job.sh
+++ b/infrastructure/jenkins_job.sh
@@ -136,24 +136,23 @@ if ! pytest -m smoke_test --env="ENVIRONMENT NAME HERE" --alluredir="$REPORT_DIR
     exit 1
 fi
 
-
 log "✅ API smoke tests passed."
 
+
 # ---- Webapp (Selenium) Tests ----
-# temporarily disabled until webapp refactor
-#TEST_WEBAPP_DIR="$BASE_DIR/test/webapp"
-#cd "$TEST_WEBAPP_DIR" || exit 1
-#
-#log "🔹 Installing webapp test dependencies..."
-#pip install --upgrade -r requirements.txt
-#
-#log "🔹 Running Selenium Webapp tests..."
-#if ! pytest --headless="True" --env="production_web_env.json"; then
-#    echo "❌ Selenium tests failed! Stopping deployment."
-#    deactivate
-#    exit 1
-#fi
-#log "✅ Selenium Webapp tests passed."
+TEST_WEBAPP_DIR="$BASE_DIR/test/webapp"
+cd "$TEST_WEBAPP_DIR" || exit 1
+
+log "🔹 Installing webapp test dependencies..."
+pip install --upgrade -r requirements.txt
+
+log "🔹 Running Selenium Webapp tests..."
+if ! pytest -m "auth and smoke" --headless="True" --env="production_web_env.json"; then
+    echo "❌ Selenium tests failed! Stopping deployment."
+    deactivate
+    exit 1
+fi
+log "✅ Selenium Webapp tests passed."
 
 deactivate
 log "✅ All tests passed. Deployment complete."

--- a/src/webapp/static/js/api_helper.js
+++ b/src/webapp/static/js/api_helper.js
@@ -46,9 +46,9 @@ const api = {
     /**
      * Handle API errors
      */
-    async handleResponse(response) {
-        // If unauthorized, redirect to login
-        if (response.status === 401) {
+    async handleResponse(response, skipAuthRedirect = false) {
+        // If unauthorized, redirect to login (unless explicitly skipped)
+        if (response.status === 401 && !skipAuthRedirect) {
             window.location.href = '/auth/login';
             return null;
         }
@@ -91,14 +91,14 @@ const api = {
     /**
      * Make POST request
      */
-    async post(endpoint, data = {}) {
+    async post(endpoint, data = {}, options = {}) {
         const response = await fetch(`${this.getBaseUrl()}${endpoint}`, {
             method: 'POST',
             headers: this.getHeaders(),
             body: JSON.stringify(data)
         });
 
-        return this.handleResponse(response);
+        return this.handleResponse(response, options.skipAuthRedirect);
     },
 
     /**

--- a/src/webapp/templates/pages/auth/account.html
+++ b/src/webapp/templates/pages/auth/account.html
@@ -314,7 +314,7 @@
                 this.deleteError = '';
 
                 try {
-                    await api.post('/api/auth/delete-account', this.deleteForm);
+                    await api.post('/api/auth/delete-account', this.deleteForm,  { skipAuthRedirect: true } );
                     // Account deleted, clear cookie and redirect
                     document.cookie = 'auth_token=; path=/; max-age=0';
                     window.location.href = '/';

--- a/src/webapp/templates/pages/auth/login.html
+++ b/src/webapp/templates/pages/auth/login.html
@@ -101,8 +101,8 @@
                 this.error = '';
 
                 try {
-                    const data = await api.post('/api/auth/login', this.formData);
-                    
+                    const data = await api.post('/api/auth/login', this.formData, { skipAuthRedirect: true });
+
                     if (data && data.access_token) {
                         // Login successful, set cookie and redirect
                         document.cookie = `auth_token=${data.access_token}; path=/; max-age=3600; SameSite=Lax`;

--- a/test/webapp/pages/base_app_page.py
+++ b/test/webapp/pages/base_app_page.py
@@ -26,3 +26,123 @@ class BaseAppPage(BasePage):
 
     def __init__(self, driver):
         super().__init__(driver)
+
+    # Navbar visibility checks
+    def is_navbar_loaded(self):
+        """Check if the navbar has loaded by verifying the brand link is visible"""
+        return self._is_active(self.navbar_brand_link_locator, timeout=3)
+
+    def is_register_button_visible(self):
+        """Check if the register button is visible (logged-out state)"""
+        return self._is_active(self.navbar_register_button_locator, timeout=2)
+
+    def is_login_button_visible(self):
+        """Check if the login button is visible (logged-out state)"""
+        return self._is_active(self.navbar_login_button_locator, timeout=2)
+
+    def is_logout_button_visible(self):
+        """Check if the logout button is visible (logged-in state)"""
+        return self._is_active(self.navbar_logout_button_locator, timeout=2)
+
+    def is_account_button_visible(self):
+        """Check if the account button is visible (logged-in state)"""
+        return self._is_active(self.navbar_account_button_locator, timeout=2)
+
+    def is_desk_link_visible(self):
+        """Check if the desk navigation link is visible (logged-in state)"""
+        return self._is_active(self.navbar_desk_link_locator, timeout=2)
+
+    def is_tasks_link_visible(self):
+        """Check if the tasks navigation link is visible (logged-in state)"""
+        return self._is_active(self.navbar_tasks_link_locator, timeout=2)
+
+    def is_projects_link_visible(self):
+        """Check if the projects navigation link is visible (logged-in state)"""
+        return self._is_active(self.navbar_projects_link_locator, timeout=2)
+
+    def is_routines_link_visible(self):
+        """Check if the routines navigation link is visible (logged-in state)"""
+        return self._is_active(self.navbar_routines_link_locator, timeout=2)
+
+    def is_reports_link_visible(self):
+        """Check if the reports navigation link is visible (logged-in state)"""
+        return self._is_active(self.navbar_reports_link_locator, timeout=2)
+
+    # Navbar interactions
+    def click_navbar_register(self):
+        """Click the register button in the navbar"""
+        self._click(self.navbar_register_button_locator)
+
+    def click_navbar_login(self):
+        """Click the login button in the navbar"""
+        self._click(self.navbar_login_button_locator)
+
+    def click_navbar_logout(self):
+        """Click the logout button in the navbar"""
+        self._click(self.navbar_logout_button_locator)
+
+    def click_navbar_account(self):
+        """Click the account button in the navbar"""
+        self._click(self.navbar_account_button_locator)
+
+    def click_navbar_desk(self):
+        """Click the desk link in the navbar"""
+        self._click(self.navbar_desk_link_locator)
+
+    def click_navbar_tasks(self):
+        """Click the tasks link in the navbar"""
+        self._click(self.navbar_tasks_link_locator)
+
+    def click_navbar_projects(self):
+        """Click the projects link in the navbar"""
+        self._click(self.navbar_projects_link_locator)
+
+    def click_navbar_routines(self):
+        """Click the routines link in the navbar"""
+        self._click(self.navbar_routines_link_locator)
+
+    def click_navbar_reports(self):
+        """Click the reports link in the navbar"""
+        self._click(self.navbar_reports_link_locator)
+
+    def click_navbar_brand(self):
+        """Click the navbar brand link (usually goes to home)"""
+        self._click(self.navbar_brand_link_locator)
+
+    # High-level state verification methods
+    def verify_logged_out_navbar_state(self):
+        """
+        Verify that the navbar shows the correct elements for a logged-out user.
+        
+        Returns:
+            bool: True if navbar is in correct logged-out state
+        """
+        return (self.is_navbar_loaded() and 
+                self.is_register_button_visible() and 
+                self.is_login_button_visible() and 
+                not self.is_logout_button_visible())
+
+    def verify_logged_in_navbar_state(self):
+        """
+        Verify that the navbar shows the correct elements for a logged-in user.
+        
+        Returns:
+            bool: True if navbar is in correct logged-in state
+        """
+        return (self.is_navbar_loaded() and 
+                self.is_logout_button_visible() and 
+                self.is_account_button_visible() and 
+                self.is_desk_link_visible() and 
+                self.is_tasks_link_visible() and 
+                self.is_projects_link_visible())
+
+    def verify_all_logged_in_nav_links_visible(self):
+        """
+        Verify that all main navigation links are visible for logged-in users.
+        
+        Returns:
+            bool: True if all navigation links are visible
+        """
+        return (self.is_desk_link_visible() and 
+                self.is_tasks_link_visible() and 
+                self.is_projects_link_visible())

--- a/test/webapp/pages/user_account_page.py
+++ b/test/webapp/pages/user_account_page.py
@@ -79,6 +79,7 @@ class AccountPage(BaseAppPage):
 
         # Wait for success message
         assert self._is_active(self.profile_success_message_locator, 5), "Profile update success message not shown"
+        self._wait_until_element_gone(self.profile_success_message_locator, 5), "Profile update success message appeared but did not disappear"
 
     def cancel_edit_profile(self):
         """Cancel profile editing"""

--- a/test/webapp/pytest.ini
+++ b/test/webapp/pytest.ini
@@ -8,3 +8,7 @@ markers =
 
     # Feature Markers
     devtest: for use only while developing new features or testing infrastructure changes
+    auth: creating users, logging in, deleting users, other authentication tests
+
+    # Entity Markers
+    tasks

--- a/test/webapp/requirements.txt
+++ b/test/webapp/requirements.txt
@@ -1,5 +1,9 @@
+allure-pytest==2.15.3
+allure-python-commons==2.15.3
 attrs==23.2.0
 certifi==2024.2.2
+charset-normalizer==3.4.7
+dotenv==0.9.9
 h11==0.14.0
 idna==3.7
 iniconfig==2.0.0
@@ -8,6 +12,8 @@ packaging==24.0
 pluggy==1.5.0
 PySocks==1.7.1
 pytest==8.2.0
+python-dotenv==1.2.2
+requests==2.33.1
 selenium==4.20.0
 sniffio==1.3.1
 sortedcontainers==2.4.0

--- a/test/webapp/tests/auth/test_auth.py
+++ b/test/webapp/tests/auth/test_auth.py
@@ -1,0 +1,371 @@
+import pytest
+import allure
+import random
+from pages.login_page import LoginPage
+from pages.user_registration_page import RegistrationPage
+from pages.user_account_page import AccountPage
+from pages.base_app_page import BaseAppPage
+
+
+@allure.feature('Authentication')
+@allure.story('User Registration')
+@pytest.mark.auth
+class TestUserRegistration:
+    """Tests for user registration flow"""
+
+    @pytest.mark.smoke
+    @allure.severity(allure.severity_level.CRITICAL)
+    def test_register_new_user_success(self, unauthenticated_driver, api_client):
+        """Test successful user registration"""
+        # Generate unique credentials
+        rand_int = random.randint(0, 99999)
+        username = f"test_reg_user{rand_int}"
+        password = f"TestPass{rand_int}!"
+
+        try:
+            with allure.step("Register new user via UI"):
+                page = RegistrationPage(unauthenticated_driver)
+                page.register_new_user(username, password)
+
+            with allure.step("Verify redirect to login page"):
+                assert '/auth/login' in unauthenticated_driver.current_url, \
+                    "User was not redirected to login page after registration"
+
+        finally:
+            # Cleanup: Delete the user via API
+            try:
+                api_client.login_user(username, password)
+                api_client.delete_user(password)
+            except Exception as e:
+                print(f"Failed to delete test user {username}: {e}")
+
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_register_duplicate_username(self, unauthenticated_driver, api_client):
+        """Test that registering with an existing username shows an error"""
+        # Create a user via API first
+        rand_int = random.randint(0, 99999)
+        username = f"test_dup_user{rand_int}"
+        password = f"TestPass{rand_int}!"
+
+        try:
+            with allure.step("Create existing user via API"):
+                api_client.register_user(username, password)
+
+            with allure.step("Attempt to register duplicate username via UI"):
+                page = RegistrationPage(unauthenticated_driver)
+                page._type(page.username_input_locator, username)
+                page._type(page.password_input_locator, password)
+                page._click(page.submit_button_locator)
+
+            with allure.step("Verify error message is displayed"):
+                assert page._is_active(page.error_message_locator, timeout=5), \
+                    "Error message not displayed for duplicate username"
+
+        finally:
+            # Cleanup
+            try:
+                api_client.login_user(username, password)
+                api_client.delete_user(password)
+            except Exception as e:
+                print(f"Failed to delete test user {username}: {e}")
+
+
+
+@allure.feature('Authentication')
+@allure.story('User Login')
+@pytest.mark.auth
+class TestUserLogin:
+    """Tests for user login flow"""
+
+    @allure.severity(allure.severity_level.CRITICAL)
+    @pytest.mark.smoke
+    def test_login_success(self, unauthenticated_driver, api_client):
+        """Test successful login with valid credentials"""
+        # Create user via API
+        rand_int = random.randint(0, 99999)
+        username = f"test_login_user{rand_int}"
+        password = f"TestPass{rand_int}!"
+
+        try:
+            with allure.step("Create test user via API"):
+                api_client.register_user(username, password)
+
+            with allure.step("Login via UI"):
+                page = LoginPage(unauthenticated_driver)
+                page.login(username, password)
+
+            with allure.step("Verify redirect to home page"):
+                assert unauthenticated_driver.current_url == unauthenticated_driver.base_url + '/', \
+                    "User was not redirected to home page after login"
+
+        finally:
+            # Cleanup: Delete user via API
+            try:
+                api_client.login_user(username, password)
+                api_client.delete_user(password)
+            except Exception as e:
+                print(f"Failed to delete test user {username}: {e}")
+
+    @allure.severity(allure.severity_level.CRITICAL)
+    def test_login_invalid_credentials(self, unauthenticated_driver):
+        """Test that invalid credentials show an error"""
+        with allure.step("Attempt login with invalid credentials"):
+            page = LoginPage(unauthenticated_driver)
+            page._type(page.username_input_locator, "nonexistent_user")
+            page._type(page.password_input_locator, "wrong_password")
+            page._click(page.submit_button_locator)
+
+        with allure.step("Verify error message is displayed"):
+            assert page._is_active(page.error_message_locator, timeout=5), \
+                "Error message not displayed for invalid credentials"
+
+
+
+@allure.feature('Navigation')
+@allure.story('Navbar Authentication State')
+@pytest.mark.auth
+class TestNavbarAuthentication:
+    """Tests for navbar changes based on authentication state"""
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_navbar_logged_out_state(self, unauthenticated_driver):
+        """Test that navbar shows correct elements when logged out"""
+        driver = unauthenticated_driver
+
+        with allure.step("Navigate to home page"):
+            driver.get(driver.base_url)
+
+        page = BaseAppPage(driver)
+
+        with allure.step("Verify navbar loads"):
+            assert page.is_navbar_loaded(), \
+                "Navbar did not load"
+
+        with allure.step("Verify logged-out buttons are visible"):
+            assert page.is_register_button_visible(), \
+                "Register button not visible when logged out"
+            assert page.is_login_button_visible(), \
+                "Login button not visible when logged out"
+
+        with allure.step("Verify logged-in elements are not visible"):
+            assert not page.is_logout_button_visible(), \
+                "Logout button should not be visible when logged out"
+            assert not page.is_desk_link_visible(), \
+                "Desk link not visible when logged in"
+            assert not page.is_tasks_link_visible(), \
+                "Tasks link not visible when logged in"
+            assert not page.is_projects_link_visible(), \
+                "Projects link not visible when logged in"
+
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_navbar_logged_in_state(self, authenticated_driver):
+        """Test that navbar shows correct elements when logged in"""
+
+        page = BaseAppPage(authenticated_driver)
+
+        with allure.step("Verify logged-in buttons are visible"):
+            assert page.is_logout_button_visible(), \
+                "Logout button not visible when logged in"
+            assert page.is_account_button_visible(), \
+                "Account button not visible when logged in"
+
+        with allure.step("Verify logged-in navigation links are visible"):
+            assert page.is_desk_link_visible(), \
+                "Desk link not visible when logged in"
+            assert page.is_tasks_link_visible(), \
+                "Tasks link not visible when logged in"
+            assert page.is_projects_link_visible(), \
+                "Projects link not visible when logged in"
+
+
+
+@allure.feature('Account Management')
+@allure.story('Account Access')
+@pytest.mark.auth
+class TestAccountManagement:
+    """Tests for account management page access and functionality"""
+
+    @allure.severity(allure.severity_level.NORMAL)
+    @pytest.mark.smoke
+    def test_access_account_page_when_logged_in(self, authenticated_driver):
+        """Test that authenticated users can access the account page"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Verify on account page"):
+            assert '/auth/account' in authenticated_driver.current_url, \
+                "Did not navigate to account page"
+
+        with allure.step("Verify username is displayed"):
+            username = page.get_username()
+            assert username, "Username not displayed on account page"
+
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_edit_profile_display_name(self, authenticated_driver):
+        """Test updating profile display name"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Get original display name"):
+            original_name = page.get_display_name()
+
+        with allure.step("Update display name"):
+            new_name = "Updated Test Name"
+            page.update_profile(name=new_name)
+
+        with allure.step("Verify display name was updated"):
+            updated_name = page.get_display_name()
+            assert updated_name == new_name, \
+                f"Display name not updated. Expected '{new_name}', got '{updated_name}'"
+            assert updated_name != original_name, \
+                "Display name did not change from original value"
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_edit_profile_timezone(self, authenticated_driver):
+        """Test updating profile timezone"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Get original timezone"):
+            original_timezone = page.get_timezone()
+
+        with allure.step("Update timezone"):
+            new_timezone = "America/Los_Angeles"
+            page.update_profile(timezone=new_timezone)
+
+        with allure.step("Verify timezone was updated"):
+            updated_timezone = page.get_timezone()
+            assert new_timezone in updated_timezone, \
+                f"Timezone not updated. Expected '{new_timezone}' in '{updated_timezone}'"
+            assert updated_timezone != original_timezone, \
+                "Timezone did not change from original value"
+
+    @allure.severity(allure.severity_level.MINOR)
+    def test_cancel_profile_edit(self, authenticated_driver):
+        """Test canceling profile edit doesn't save changes"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Get original display name"):
+            original_name = page.get_display_name()
+
+        with allure.step("Start editing and make changes"):
+            page.start_edit_profile()
+            page._type(page.name_input_locator, "This should not be saved")
+
+        with allure.step("Cancel edit"):
+            page.cancel_edit_profile()
+
+        with allure.step("Verify name was not changed"):
+            current_name = page.get_display_name()
+            assert current_name == original_name, \
+                "Display name changed after canceling edit"
+
+    @allure.severity(allure.severity_level.CRITICAL)
+    def test_change_password(self, authenticated_driver, test_user):
+        """Test changing account password"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        old_password = test_user['password']
+        new_password = "NewTestPassword123!"
+
+        with allure.step("Change password"):
+            page.change_password(old_password, new_password)
+
+        with allure.step("Verify still on account page"):
+            assert '/auth/account' in authenticated_driver.current_url, \
+                "Unexpected redirect after password change"
+
+        with allure.step("Change password back for cleanup"):
+            page.change_password(new_password, old_password)
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_change_password_wrong_old_password(self, authenticated_driver):
+        """Test that changing password with wrong old password shows error"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Attempt to change password with incorrect old password"):
+            page._type(page.old_password_input_locator, "wrong_password")
+            page._type(page.new_password_input_locator, "NewPassword123!")
+            page._click(page.change_password_button_locator)
+
+        with allure.step("Verify error message is displayed"):
+            assert page.has_password_error(), \
+                "Error message not displayed for incorrect old password"
+
+
+@allure.feature('Account Management')
+@allure.story('Account Deletion')
+@pytest.mark.auth
+class TestAccountDeletion:
+    """Tests for account deletion through UI"""
+
+    @allure.severity(allure.severity_level.CRITICAL)
+    def test_delete_account_success(self, unauthenticated_driver, api_client):
+        """Test successfully deleting an account through the UI"""
+        # Create user via API
+        rand_int = random.randint(0, 99999)
+        username = f"test_delete_user{rand_int}"
+        password = f"TestPass{rand_int}!"
+
+        with allure.step("Create test user via API"):
+            api_client.register_user(username, password)
+
+        with allure.step("Login via UI"):
+            login_page = LoginPage(unauthenticated_driver)
+            login_page.login(username, password)
+
+        with allure.step("Navigate to account page and delete account"):
+            account_page = AccountPage(unauthenticated_driver)
+            account_page.delete_account(password)
+
+        with allure.step("Verify redirect to home page"):
+            assert unauthenticated_driver.current_url == unauthenticated_driver.base_url + '/', \
+                "User was not redirected to home page after account deletion"
+
+        with allure.step("Verify user is logged out"):
+            page = BaseAppPage(unauthenticated_driver)
+            assert page.is_register_button_visible(), \
+                "User appears to still be logged in after account deletion"
+
+
+    @allure.severity(allure.severity_level.MINOR)
+    def test_delete_account_cancel(self, authenticated_driver):
+        """Test canceling account deletion"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Start deletion and cancel"):
+            page.cancel_delete()
+
+        with allure.step("Verify still on account page"):
+            assert '/auth/account' in authenticated_driver.current_url, \
+                "Unexpected navigation after canceling account deletion"
+
+
+    @allure.severity(allure.severity_level.NORMAL)
+    def test_delete_account_wrong_password(self, authenticated_driver):
+        """Test that deleting account with wrong password shows error"""
+        with allure.step("Navigate to account page"):
+            page = AccountPage(authenticated_driver)
+
+        with allure.step("Attempt to delete account with wrong password"):
+            page._click(page.delete_button_locator)
+            assert page._is_active(page.delete_password_input_locator, 3), \
+                "Delete confirmation form did not appear"
+
+            page._type(page.delete_password_input_locator, "wrong_password")
+            page._click(page.confirm_delete_button_locator)
+
+        with allure.step("Verify error message is displayed"):
+            assert page.has_delete_error(), \
+                "Error message not displayed for incorrect password during deletion"
+
+        with allure.step("Verify still on account page (deletion failed)"):
+            assert '/auth/account' in authenticated_driver.current_url, \
+                "Unexpected navigation after failed deletion"


### PR DESCRIPTION
This branch brings a test suite for webapp auth behaviors: registering an account, logging in, editing an account through the account page, deleting an account.

also, the webapp's client side API client typically redirects to the login page on all http 401 responses, but now allows a param to be passed to skip that. This is only useful when the cause of the 401 is "user entered invalid credentials" and we want to stay on the same page and just show an error. 

Also uncommented the webapp tests from the jenkins example script, we should be able to use the auth tests as a smoke test for webapp functionality (staging and production will need env files)